### PR TITLE
fixup: update base url to point to repo for corrections

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -4,7 +4,7 @@ description: |
   Some stuff I've done.
 output_dir: "_site"
 base_url: https://alexkgold.space
-repository_url: https://github.com/akgold/
+repository_url: https://github.com/akgold/akg_site/
 google_analytics: "UA-133127514-1"
 twitter:
   site: "@alexkgold"


### PR DESCRIPTION
the current behavior links the footer content "If you see mistakes or want to suggest changes, please create an issue on the source repository."
to just github.com/akgold/issues/new. I believe this will update the theme to properly link to this repo.

Note - I did not pull the repo locally to build. I tried searching for the string within the repo (via github search) and did not see any its for where the code for the footer is generated - so a quick search for distill got to https://github.com/rstudio/distill/blob/main/R/appendices.R#L51 which confirmed

```
   issues_url <- metadata$repository_url
    if (grepl("github.com", issues_url, fixed = TRUE)) {
      issues_url <- sub("/$", "", issues_url)
      issues_url <- paste0(issues_url, "/issues/new")
    }
```

so it seems either https://github.com/akgold/akg_site/ or https://github.com/akgold/akg_site should work
